### PR TITLE
fix seed max value

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -205,7 +205,7 @@ class MochiSampler:
                 "num_frames": ("INT", {"default": 49, "min": 7, "max": 1024, "step": 6}),
                 "steps": ("INT", {"default": 50, "min": 2}),
                 "cfg": ("FLOAT", {"default": 4.5, "min": 0.0, "max": 30.0, "step": 0.01}),
-                "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2**32 - 1}),
             },
         }
 


### PR DESCRIPTION
First of all, congratulation on the wonderful work! The results are amazing!

However, after changing the seed to random mode, I encountered an error, which seems to be caused by an unreasonable maximum value setting for the seed. Therefore, I made modifications to address this error.
```
Traceback (most recent call last):
  File "/root/autodl-tmp/ComfyUI/execution.py", line 323, in execute
    output_data, output_ui, has_subgraph = get_output_data(obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
  File "/root/autodl-tmp/ComfyUI/execution.py", line 198, in get_output_data
    return_values = _map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
  File "/root/autodl-tmp/ComfyUI/execution.py", line 169, in _map_node_over_list
    process_inputs(input_dict, i)
  File "/root/autodl-tmp/ComfyUI/execution.py", line 158, in process_inputs
    results.append(getattr(obj, func)(**inputs))
  File "/root/autodl-tmp/ComfyUI/custom_nodes/ComfyUI-MochiWrapper/nodes.py", line 237, in process
    latents = model.run(args, stream_results=False)
  File "/root/miniconda3/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/root/autodl-tmp/ComfyUI/custom_nodes/ComfyUI-MochiWrapper/mochi_preview/t2v_synth_mochi.py", line 243, in run
    np.random.seed(args["seed"])
  File "numpy/random/mtrand.pyx", line 4806, in numpy.random.mtrand.seed
  File "numpy/random/mtrand.pyx", line 250, in numpy.random.mtrand.RandomState.seed
  File "_mt19937.pyx", line 168, in numpy.random._mt19937.MT19937._legacy_seeding
  File "_mt19937.pyx", line 182, in numpy.random._mt19937.MT19937._legacy_seeding
ValueError: Seed must be between 0 and 2**32 - 1
```

Finally, thanks for your great work!