### PR TITLE
Use float16 for autocast on mps

### DIFF
--- a/mochi_preview/t2v_synth_mochi.py
+++ b/mochi_preview/t2v_synth_mochi.py
@@ -240,7 +240,10 @@ class T2VSynthMochiModel:
         if hasattr(self.dit, "cublas_half_matmul") and self.dit.cublas_half_matmul:
             autocast_dtype = torch.float16
         else:
-            autocast_dtype = torch.bfloat16
+            if self.device.type == "mps":
+                autocast_dtype = torch.float16
+            else:
+                autocast_dtype = torch.bfloat16
 
         def model_fn(*, z, sigma, cfg_scale):
             nonlocal sample, sample_null

--- a/nodes.py
+++ b/nodes.py
@@ -177,14 +177,15 @@ class DownloadAndLoadMochiModel:
                     nonlinearity="silu",
                     output_nonlinearity="silu",
                     causal=True,
+                    dtype=dtype,
                 )
         vae_sd = load_torch_file(vae_path)
         if is_accelerate_available:
             for key in vae_sd:
-                set_module_tensor_to_device(vae, key, dtype=torch.bfloat16, device=offload_device, value=vae_sd[key])
+                set_module_tensor_to_device(vae, key, dtype=dtype, device=offload_device, value=vae_sd[key])
         else:
             vae.load_state_dict(vae_sd, strict=True)
-            vae.eval().to(torch.bfloat16).to("cpu")
+            vae.eval().to(dtype).to("cpu")
         del vae_sd
 
         return (model, vae,)


### PR DESCRIPTION
On mps, it only supports `float16` for `autocast`.
Use `float16` instead of `bfloat16` on mps for now.

This patch also use `dtype` for vae as well so that it can use `bfloat16` or `float16` on mps and other environment.